### PR TITLE
Exclude extensions `.html` and `.css`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+## 0.0.5
+- Exclude extensions `.html` and` .css`
+
 ## 0.0.4
 - README fix
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "tt",
     "displayName": "Template Toolkit",
     "description": "VS Code support for Perl Template Toolkit syntax",
-    "version": "0.0.4",
+    "version": "0.0.5",
     "publisher": "samosad",
     "repository": {
         "type": "git",
@@ -39,9 +39,7 @@
                 "extensions": [
                     ".tt",
                     ".tt3",
-                    ".html",
-                    ".html.tt",
-                    ".css"
+                    ".html.tt"
                 ],
                 "configuration": "./language-configuration.json"
             }


### PR DESCRIPTION
Hi there.

In order to solve issue #2, I excluded `.html` and `.css`.
I think that these extensions are not the default, and should be set only when necessary.